### PR TITLE
Add include markdown plugin to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs==1.5.3
 mkdocs-material==9.5.13
 mkdocs-material-extensions>=1.3.1
 pymdown-extensions==10.7
+mkdocs-include-markdown-plugin>=4.0.0


### PR DESCRIPTION
## Summary
- append mkdocs-include-markdown-plugin dependency to requirements

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684176c5f910832f9d9c268fe5eee448